### PR TITLE
Implement `connect` for higher order ember components

### DIFF
--- a/addon/lib/connect.js
+++ b/addon/lib/connect.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+import reduxStore from '../services/redux-store';
+
+const {
+  computed,
+  defineProperty,
+  inject: { service }
+} = Ember;
+
+export default function connect(mapStateToComputed, mapDispatchToActions, storeService) {
+  return function wrapWithConnect(WrappedComponent) {
+    return WrappedComponent.extend({
+      reduxStore: storeService || service('reduxStore'),
+
+      init() {
+        this._super(...arguments);
+        this.actions = this.actions || {};
+        const propMap = Ember.typeOf(mapStateToComputed) === 'function' ? 
+          mapStateToComputed(reduxStore) :
+          mapStateToComputed;
+        Object.keys(propMap).forEach((key) => {
+          const value = propMap[key];
+          const property = Ember.typeOf(value) === 'function' ? 
+            value() :
+            computed.reads(`reduxStore.state.${value}`);
+          defineProperty(this, key, property);
+        });
+        const store = this.get('reduxStore');
+        const actionMap = Ember.typeOf(mapDispatchToActions) === 'function' ?
+          mapDispatchToActions(store && store.dispatch.bind(store), this) : 
+          mapDispatchToActions;
+
+        Object.keys(actionMap).forEach((key) => {
+          const value = actionMap[key];
+          const action = Ember.typeOf(value) === 'function' ?
+            value :
+            () => {
+              const store = this.get('reduxStore');
+              return store && this.get('reduxStore').dispatch({type: value});
+            };
+          this.actions[key] = action;
+        });
+      }
+    });
+  };
+}

--- a/tests/unit/lib/connect-test.js
+++ b/tests/unit/lib/connect-test.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import connect from 'ember-cli-redux/lib/connect';
+import { module, test } from 'qunit';
+
+module('Unit | Lib | Connect');
+
+function createFakeReduxService(state = {}, dispatch = null) {
+  return Ember.Object.extend({state, dispatch}).create();
+}
+
+test('it works', function(assert) {
+  const subject = connect();
+  assert.ok(subject);
+});
+
+test('statemap strings become one way aliases', function(assert) {
+  const fakeReduxService = createFakeReduxService({ someReduxProp: 'ok' });
+  const stateToComputed = { someProp: 'someReduxProp' };
+  const component = connect(stateToComputed, {}, fakeReduxService)(Ember.Object).create();
+  assert.equal(component.get('someProp'), 'ok');
+});
+
+test('statemaps accept custom functions', function(assert) {
+  const fakeReduxService = createFakeReduxService({ someReduxProp: 'ok' });
+  const stateToComputed = {
+    someProp: () => Ember.computed.reads('reduxStore.state.someReduxProp')
+  };
+  const component = connect(stateToComputed, {}, fakeReduxService)(Ember.Object).create();
+  assert.equal(component.get('someProp'), 'ok');
+});
+
+test('actionMap strings become dispatches without payloads', function(assert) {
+  const fakeReduxService = createFakeReduxService({}, action => action);
+  const dispatchToActions = {emberAction: 'REDUX_ACTION_TYPE'};
+  const objectWithActions = Ember.Object.extend({actions: {}});
+  const component = connect({}, dispatchToActions, fakeReduxService)(objectWithActions).create();
+  assert.equal(component.actions.emberAction().type, 'REDUX_ACTION_TYPE');
+});
+
+test('actionMap functions operate as action creators', function(assert) {
+  const fakeReduxService = createFakeReduxService({}, action => action);
+  const dispatchToActions = {emberAction: () => {
+    return {type: 'REDUX_ACTION_TYPE'};
+  }};
+  const objectWithActions = Ember.Object.extend({actions: {}});
+  const component = connect({}, dispatchToActions, fakeReduxService)(objectWithActions).create();
+  assert.equal(component.actions.emberAction().type, 'REDUX_ACTION_TYPE');
+});

--- a/tests/unit/lib/ember-logger-middleware-test.js
+++ b/tests/unit/lib/ember-logger-middleware-test.js
@@ -1,4 +1,3 @@
-// import Ember from 'ember';
 import emberLoggerMiddleware from 'ember-cli-redux/lib/ember-logger-middleware';
 import { module, test } from 'qunit';
 


### PR DESCRIPTION
Experimental feature. See https://github.com/AltSchool/ember-cli-redux/issues/1 for background.

I've created a [branch of a TodoMVC app](https://github.com/matthewconstantine/ember-cli-redux-todos/pull/1) that demonstrates connect.
